### PR TITLE
Try to fix the perma green problem

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -209,12 +209,13 @@ UserPresence = {
 			const connectionHandle = UserPresence.getConnectionHandle(connection.id);
 			connection.onClose(function() {
 				// mark connection as closed so if it drops in the middle of the process it doesn't even is created
-				if (connectionHandle) {
-					connectionHandle.closed = true;
+				if (!connectionHandle) {
+					return;
+				}
+				connectionHandle.closed = true;
 
-					if (connectionHandle.UserPresenceUserId != null) {
-						UserPresence.removeConnection(connection.id);
-					}
+				if (connectionHandle.UserPresenceUserId != null) {
+					UserPresence.removeConnection(connection.id);
 				}
 			});
 		});

--- a/server/server.js
+++ b/server/server.js
@@ -66,13 +66,30 @@ UserPresence = {
 		UsersSessions.remove({});
 	},
 
+	getConnectionHandle(connectionId) {
+		const internalConnection = Meteor.server.sessions.get(connectionId);
+
+		if (!internalConnection) {
+			return;
+		}
+
+		return internalConnection.connectionHandle;
+	},
+
 	createConnection: function(userId, connection, status, metadata) {
 		// if connections is invalid, does not have an userId or is already closed, don't save it on db
 		if (!userId || !connection.id || connection.closed) {
 			return;
 		}
 
+		const connectionHandle = UserPresence.getConnectionHandle(connection.id);
+
+		if (!connectionHandle || connectionHandle.closed) {
+			return;
+		}
+
 		connection.UserPresenceUserId = userId;
+		connectionHandle.UserPresenceUserId = userId;
 
 		status = status || 'online';
 
@@ -109,7 +126,7 @@ UserPresence = {
 		}
 
 		// make sure closed connections are being created
-		if (!connection.closed) {
+		if (!connection.closed && !connectionHandle.closed) {
 			UsersSessions.upsert(query, update);
 		}
 	},
@@ -190,8 +207,12 @@ UserPresence = {
 
 	start: function() {
 		Meteor.onConnection(function(connection) {
+			const connectionHandle = UserPresence.getConnectionHandle(connection.id);
 			connection.onClose(function() {
 				// mark connection as closed so if it drops in the middle of the process it doesn't even is created
+				if (connectionHandle) {
+					connectionHandle.closed = true;
+				}
 				connection.closed = true;
 
 				var result = UserPresence.removeConnection(connection.id);
@@ -222,9 +243,13 @@ UserPresence = {
 		}
 
 		Meteor.publish(null, function() {
-			if (this.userId == null && this.connection.UserPresenceUserId !== undefined && this.connection.UserPresenceUserId !== null) {
-				UserPresence.removeConnection(this.connection.id);
-				delete this.connection.UserPresenceUserId;
+			if (this.userId == null && this.connection && this.connection.id) {
+				const connectionHandle = UserPresence.getConnectionHandle(this.connection.id);
+				if (connectionHandle && (this.connection.UserPresenceUserId != null || connectionHandle.UserPresenceUserId != null)) {
+					UserPresence.removeConnection(this.connection.id);
+					delete this.connection.UserPresenceUserId;
+					delete connectionHandle.UserPresenceUserId;
+				}
 			}
 
 			this.ready();


### PR DESCRIPTION
- Uses the `Meteor.server.sessions.get` to share variables since the context connection is not sharing anymore.
- Prevent session creation if `Meteor.server.sessions.get` doesn't exists meaning that the connection is gone.

May fix a race condition when the mobile app calls the `UserPresence:away` when killing the app what calls the `onClose` method as well. If the `UserPresence:away` delays for some milliseconds it may happen after the `onClose` recreating the session.