### PR TITLE
Fix: duplicate connections inserted for a usersSession

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -126,8 +126,16 @@ UserPresence = {
 
 		// make sure closed connections are being created
 		if (!connectionHandle.closed) {
-			UsersSessions.upsert(query, update);
-		}
+      // prevent duplicate connectionIds from being inserted into the connections array
+      const existingSession = UsersSessions.findOne({
+        _id: userId,
+        'connections.id': connection.id
+      });
+
+      if (!existingSession) {
+        UsersSessions.upsert(query, update);
+      }
+    }
 	},
 
 	setConnection: function(userId, connection, status) {


### PR DESCRIPTION
When digging into an issue where our users were showing as always online. We took the approach of regularly cleaning up any 'stale' usersSessions since especially during deploys we noticed that certain usersSessions were not getting removed even though the instances no longer existed in the instances collection.

Here is a screenshot of the cleanup batch job:
![image](https://user-images.githubusercontent.com/11020939/83925320-d91efe80-a754-11ea-905d-2e11f4912983.png)

It seems like the logic here does not run on our aws deploys since the users that are stuck in this permanently online state seem to be connected to instances that no longer exist.

![image](https://user-images.githubusercontent.com/11020939/83925413-184d4f80-a755-11ea-8033-01de6e101f56.png)

A secondary and perhaps minor issue we noticed was that usersSessions had duplicate connections to the same instance with the same connectionId:

```
{ 
    "_id" : "rnrNGnNhiyqoywgD3", 
    "connections" : [
        {
            "id" : "jr6kwLY7rWFQaBPx6", 
            "instanceId" : "EpuQbnoXPvCkKb7yA", 
            "status" : "online", 
            "_createdAt" : ISODate("2020-06-05T21:27:32.698+0000"), 
            "_updatedAt" : ISODate("2020-06-05T21:27:32.698+0000")
        }, 
        {
            "id" : "jr6kwLY7rWFQaBPx6", 
            "instanceId" : "EpuQbnoXPvCkKb7yA", 
            "status" : "online", 
            "_createdAt" : ISODate("2020-06-05T21:27:31.238+0000"), 
            "_updatedAt" : ISODate("2020-06-05T21:27:31.238+0000")
        }, 
    ]
}
```

This PR fixes that duplicate connection issue. 